### PR TITLE
Provide better postion in a small viewpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # calculate-position
 
-Calculates the best position (left/top coords) for a given anchor and dimensions. 
+Calculates the best position (left/top coords) for a given anchor and dimensions.
 
-Mostly useful for placing popups and tooltips correctly in the viewports. 
+Mostly useful for placing popups and tooltips correctly in the viewports.
 
 Behind the scenes we calculate all the position positions for the popup element (TopLeft, TopRight etc) and then choose the one that has the largest overlap with the viewport (normal the window).
 
@@ -13,8 +13,10 @@ Calculates the best direction (e.g. BottomLeft) for a given anchor and dimension
 Valid directions are:
 - `TopLeft`
 - `TopRight`
+- `TopCenter`
 - `BottomLeft`
 - `BottomRight`
+- `BottomCenter`
 
 `BottomRight` is the default direction.
 
@@ -27,7 +29,7 @@ Valid arguments:
 
 Example:
 ```js
-import calculateBestDirection from 'calculate-position'
+import {calculateBestDirection} from 'calculate-position'
 
 const anchor = popupAnchorElement.getBoundingClientRect()
 const dimensions = {width: popupWidth, height: popupHeight}
@@ -38,7 +40,7 @@ console.log(calculateBestDirection({anchor, dimensions}))
 
 ### calculateBestPosition
 
-Returns coordinates (i.e. `top` and `left`) for a given anchor and dimensions. 
+Returns coordinates (i.e. `top` and `left`) for a given anchor and dimensions.
 
 Valid arguments:
 ```
@@ -49,7 +51,7 @@ Valid arguments:
 
 Example:
 ```js
-import calculateBestPosition from 'calculate-position'
+import {calculateBestPosition} from 'calculate-position'
 
 const anchor = anchorElement.getBoundingClientRect()
 const dimensions = {width: popupWidth, height: popupHeight}

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "keywords": [],
   "scripts": {
     "build": "run-p build:*",
-    "build:main": "tsc -p tsconfig.json",
-    "build:module": "tsc -p tsconfig.module.json",
+    "build:main": "tsc --build tsconfig.json",
+    "build:module": "tsc --build tsconfig.module.json",
     "fix": "run-s fix:*",
     "fix:prettier": "prettier \"src/**/*.ts\" --write",
     "fix:lint": "eslint src --ext .ts --fix",

--- a/src/lib/direction.spec.ts
+++ b/src/lib/direction.spec.ts
@@ -50,6 +50,30 @@ test('calculateBestDirection BottomLeft', (t) => {
   );
 });
 
+test('calculateBestDirection BottomCenter', (t) => {
+  const viewport = {
+    width: 400,
+    height: 600,
+  };
+
+  const anchor = {
+    left: 200,
+    top: 100,
+    width: 0,
+    height: 30,
+  };
+
+  const dimensions = {
+    width: 300,
+    height: 200,
+  };
+
+  t.deepEqual(
+    calculateBestDirection({ anchor, dimensions, viewport }),
+    Direction.BottomCenter
+  );
+});
+
 test('calculateBestDirection TopLeft', (t) => {
   const viewport: Dimensions = {
     width: 800,
@@ -95,6 +119,30 @@ test('calculateBestDirection TopRight', (t) => {
   t.deepEqual(
     calculateBestDirection({ anchor, dimensions, viewport }),
     Direction.TopRight
+  );
+});
+
+test('calculateBestDirection TopCenter', (t) => {
+  const viewport: Dimensions = {
+    width: 400,
+    height: 600,
+  };
+
+  const anchor: Rectangle = {
+    left: 300,
+    top: 600 - 300,
+    width: 300,
+    height: 300,
+  };
+
+  const dimensions: Dimensions = {
+    width: 350,
+    height: 200,
+  };
+
+  t.deepEqual(
+    calculateBestDirection({ anchor, dimensions, viewport }),
+    Direction.TopCenter
   );
 });
 

--- a/src/lib/direction.ts
+++ b/src/lib/direction.ts
@@ -22,9 +22,11 @@ import { Dimensions, Direction, DirectionPoint, Rectangle } from './types';
 export const getDirections = ({
   anchor,
   dimensions,
+  viewport,
 }: {
   anchor: Rectangle;
   dimensions: Dimensions;
+  viewport?: Dimensions;
 }): DirectionPoint => {
   return {
     [Direction.BottomRight]: {
@@ -35,6 +37,10 @@ export const getDirections = ({
       left: anchor.left - dimensions.width,
       top: anchor.top + anchor.height,
     },
+    [Direction.BottomCenter]: {
+      left: Math.round(((viewport?.width ?? 0) - dimensions.width) / 2),
+      top: anchor.top + anchor.height,
+    },
     [Direction.TopRight]: {
       left: anchor.left + anchor.width,
       top: anchor.top - dimensions.height,
@@ -42,6 +48,10 @@ export const getDirections = ({
     [Direction.TopLeft]: {
       left: anchor.left - dimensions.width,
       top: anchor.top - dimensions.height,
+    },
+    [Direction.TopCenter]: {
+      left: Math.round(((viewport?.width ?? 0) - dimensions.width) / 2),
+      top: anchor.top - anchor.height,
     },
   };
 };
@@ -97,6 +107,7 @@ export const calculateBestDirection = ({
   directions = getDirections({
     anchor,
     dimensions,
+    viewport,
   }),
 }: {
   anchor: Rectangle;

--- a/src/lib/position.spec.ts
+++ b/src/lib/position.spec.ts
@@ -1,7 +1,7 @@
 import test from 'ava';
 import { calculateBestPosition } from './position';
 
-test('calculateBestPosition', (t) => {
+test('calculateBestPosition 1', (t) => {
   const viewport = {
     width: 800,
     height: 600,
@@ -22,5 +22,29 @@ test('calculateBestPosition', (t) => {
   t.deepEqual(calculateBestPosition({ anchor, dimensions, viewport }), {
     left: 300,
     top: 300,
+  });
+});
+
+test('calculateBestPosition 2', (t) => {
+  const viewport = {
+    width: 400,
+    height: 600,
+  };
+
+  const anchor = {
+    left: 200,
+    top: 100,
+    width: 0,
+    height: 30,
+  };
+
+  const dimensions = {
+    width: 300,
+    height: 200,
+  };
+
+  t.deepEqual(calculateBestPosition({ anchor, dimensions, viewport }), {
+    left: 50,
+    top: 130,
   });
 });

--- a/src/lib/position.ts
+++ b/src/lib/position.ts
@@ -33,7 +33,7 @@ export const calculateBestPosition = ({
   dimensions: Dimensions;
   viewport?: Dimensions;
 }): Point => {
-  const directions = getDirections({ anchor, dimensions });
+  const directions = getDirections({ anchor, dimensions, viewport });
 
   const direction = calculateBestDirection({
     anchor,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,8 +11,10 @@ export interface Point {
 export enum Direction {
   BottomRight = 'BottomRight',
   BottomLeft = 'BottomLeft',
+  BottomCenter = 'BottomCenter',
   TopRight = 'TopRight',
   TopLeft = 'TopLeft',
+  TopCenter = 'TopCenter',
 }
 
 export interface Rectangle {

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "esnext",
     "outDir": "build/module",
     "module": "esnext"
   },


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

When the viewpoint is small enough, Putting the popup on the left or right will both cause the popup to be displayed incompletely. In such a case, putting it in the center is a better choice. 

- **What is the current behavior?** (You can also link to an open issue here)



![image](https://user-images.githubusercontent.com/24715727/137087326-f5b92a01-f2a3-4c0f-bd2c-312dd6713069.png)

(viewpoint width is 400px width and popup width is 350px)

- **What is the new behavior (if this is a feature change)?**

![CleanShot 2021-10-13 at 15 28 29](https://user-images.githubusercontent.com/24715727/137087021-4f936b9e-c0e1-4d4a-9e31-16624d246d74.png)


- **Other information**:

N/A